### PR TITLE
Bug Fix file_relocater.py: force absolute pathing

### DIFF
--- a/modules/addons/file_relocater.py
+++ b/modules/addons/file_relocater.py
@@ -639,6 +639,12 @@ def main():
     """
     Main function for the audio organizer.
     """
+    # Capture the original working directory before any potential changes
+    # This ensures relative paths are resolved from where the user ran the command
+    original_cwd = os.environ.get('PWD', os.getcwd())
+    if not original_cwd or not os.path.isdir(original_cwd):
+        original_cwd = os.getcwd()
+    
     args = parse_arguments()
     
     # Set logging level
@@ -690,6 +696,16 @@ def main():
         return
     
     # Validate source and destination
+    # Convert to absolute paths to avoid issues with relative paths
+    # Use original working directory for relative path resolution
+    if not os.path.isabs(args.source):
+        args.source = os.path.join(original_cwd, args.source)
+    args.source = os.path.abspath(args.source)
+    
+    if not os.path.isabs(args.destination):
+        args.destination = os.path.join(original_cwd, args.destination)
+    args.destination = os.path.abspath(args.destination)
+    
     if not os.path.exists(args.source):
         logger.error(f"Source directory does not exist: {args.source}")
         sys.exit(1)


### PR DESCRIPTION
… global CLI

<!-- Use this format for title: Added (Component): (Name), Bug Fix (Name): (Desc), Updated (Name): (Desc), Documentation: (Description)-->
## Description
<!-- Provide a brief description of the changes in this pull request -->
made file_relocater ALWAYS use absolute paths even if called from the global CLI

## Type of Change
<!-- Mark the relevant option with an "X" -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
<!-- Mark completed items with an "X" -->
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and followed them
- [X] I have added the required header to any new files
- [X] I have updated the README.md if necessary
- [X] I have the right to contribute this code and agree to license it under the project's BSD-3-Clause license

## Additional Notes
<!-- Any additional information, concerns, or notes for reviewers -->
