### PR TITLE
fixed FLAC conversions not setting the right bitdepth

### DIFF
--- a/modules/addons/convert.py
+++ b/modules/addons/convert.py
@@ -392,10 +392,19 @@ class AudioConverter:
         if self.bit_depth and self.output_format in ('flac', 'wav'):
             if self.bit_depth == '16':
                 cmd.extend(['-sample_fmt', 's16'])
+                # For FLAC, explicitly set the encoded bit depth
+                if self.output_format == 'flac':
+                    cmd.extend(['-bits_per_raw_sample', '16'])
             elif self.bit_depth == '24':
                 cmd.extend(['-sample_fmt', 's32'])
+                # For FLAC, explicitly set the encoded bit depth
+                if self.output_format == 'flac':
+                    cmd.extend(['-bits_per_raw_sample', '24'])
             elif self.bit_depth == '32':
                 cmd.extend(['-sample_fmt', 's32'])
+                # For FLAC, explicitly set the encoded bit depth
+                if self.output_format == 'flac':
+                    cmd.extend(['-bits_per_raw_sample', '32'])
         
         # Encoding mode and bitrate for lossy formats
         encoding_mode = self.encoding_mode or 'vbr'


### PR DESCRIPTION
<!--REMINDER: type "bot, check" (without quotes) in the PR to have it check your code and commit before human review otherwise it won't be reviewed-->
<!-- Use this format for title: (Type of Change): (description). 
for example, Bug Fix: changed blue button to red-->
## Description
<!-- Provide a brief description of the changes in this pull request -->
Bitdepth user set was being ignored specifically when converting to FLAC files as ffmpeg needs a different flag for FLAC bit depth.

## Type of Change
<!-- Mark any relevant options with an "X" -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
<!-- Mark completed items with an "X" -->
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and followed them
- [X] I have updated any documentation if necessary
- [X] I have the right to contribute this code and agree to license it under the project's current license
- [X] I will type "bot, check" (without quotes) after sending this pull request

## Additional Notes
<!-- Any additional information, concerns, or notes for reviewers -->